### PR TITLE
Added new Client options for connection pool config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ python tempodb-read-demo.py
 
 # Classes
 
-## Client(key, secret, *host="api.tempo-db.com"*, *port=443*, *secure=True*)
+## Client(key, secret, *host="api.tempo-db.com"*, *port=443*, *secure=True*, *pool_connections=10*, *pool_maxsize=10*)
 Stores the session information for authenticating and accessing TempoDB. Your api key and secret is required. The Client
 also allows you to specify the hostname, port, and protocol (http or https). This is used if you are on a private cluster.
 The default hostname and port should work for the standard cluster.
@@ -44,6 +44,8 @@ All access to data is made through a client instance.
 * host - hostname for the cluster (string)
 * port - port for the cluster (int)
 * secure - protocol to use (True=https, False=http)
+* pool_connections - default connection poolsize
+* pool_maxsize - maximum number of connections to open within the pool
 
 ## DataPoint(ts, value)
 Represents one timestamp/value pair.

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -26,13 +26,15 @@ RE_VALID_SERIES_KEY = re.compile(VALID_SERIES_KEY)
 
 class Client(object):
 
-    def __init__(self, key, secret, host=API_HOST, port=API_PORT, secure=True):
+    def __init__(self, key, secret, host=API_HOST, port=API_PORT, secure=True, pool_connections=10, pool_maxsize=10):
         self.key = key
         self.secret = secret
         self.host = host
         self.port = port
         self.secure = secure
         self.session = requests.session()
+        self.session.mount('http://', requests.adapters.HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize))
+        self.session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize))
 
     def create_database(self, name=""):
         params = {


### PR DESCRIPTION
The default connection pool size in Python requests is 10. This is
insufficient for high volume requests because the pool will be quickly
exhausted with an "HttpConnectionPool is full, discarding connection:
api.tempo-db.com" error. This allows the user to configure the poolsize
to meet their own requirements if the default is insufficient.
