### PR TITLE
Make api credentials constant for easier configuration

### DIFF
--- a/tempodb/demo/tempodb-bulk-write-demo.py
+++ b/tempodb/demo/tempodb-bulk-write-demo.py
@@ -5,7 +5,12 @@ http://tempo-db.com/api/write-series/#bulk-write-multiple-series
 import datetime
 from tempodb import Client
 
-client = Client('your-api-key', 'your-api-secret')
+# Modify these with your credentials found at: http://tempo-db.com/manage/
+API_KEY = 'your-api-key'
+API_SECRET = 'your-api-secret'
+SERIES_KEY = 'your-custom-key'
+
+client = Client(API_KEY, API_SECRET)
 
 ts = datetime.datetime.now()
 data = [

--- a/tempodb/demo/tempodb-read-demo.py
+++ b/tempodb/demo/tempodb-read-demo.py
@@ -5,12 +5,17 @@ http://tempo-db.com/api/read-series/#read-series-by-key
 import datetime
 from tempodb import Client
 
-client = Client('your-api-key', 'your-api-secret')
+# Modify these with your settings found at: http://tempo-db.com/manage/
+API_KEY = 'your-api-key'
+API_SECRET = 'your-api-secret'
+SERIES_KEY = 'your-custom-key'
+
+client = Client(API_KEY, API_SECRET)
 
 start = datetime.date(2012, 1, 1)
 end = start + datetime.timedelta(days=1)
 
-data = client.read_key('your-custom-key', start, end)
+data = client.read_key(SERIES_KEY, start, end)
 
 for datapoint in data.data:
     print datapoint

--- a/tempodb/demo/tempodb-write-demo.py
+++ b/tempodb/demo/tempodb-write-demo.py
@@ -6,7 +6,12 @@ import datetime
 import random
 from tempodb import Client, DataPoint
 
-client = Client('your-api-key', 'your-api-secret')
+# Modify these with your credentials found at: http://tempo-db.com/manage/
+API_KEY = 'your-api-key'
+API_SECRET = 'your-api-secret'
+SERIES_KEY = 'your-custom-key'
+
+client = Client(API_KEY, API_SECRET)
 
 date = datetime.datetime(2012, 1, 1)
 
@@ -20,4 +25,4 @@ for day in range(1, 10):
         data.append(DataPoint(date, random.random() * 50.0))
         date = date + datetime.timedelta(minutes=1)
 
-    client.write_key('your-custom-key', data)
+    client.write_key(SERIES_KEY, data)


### PR DESCRIPTION
Going through the getting started docs, I missed changing some of these values. It seems easier to have these values constantized at the top so newbies know what they need to change.

What do you guys think?
