### PR TITLE
requests v1.0 is required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 install_requires = [
     'python-dateutil==1.5',
-    'requests',
+    'requests==1.0',
     'simplejson',
 ]
 


### PR DESCRIPTION
Client is using requests's Session.mount() which was introduced in v1.0.0
