### PR TITLE
Incorrect series validation regex

### DIFF
--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -20,9 +20,6 @@ API_HOST = 'api.tempo-db.com'
 API_PORT = 443
 API_VERSION = 'v1'
 
-VALID_SERIES_KEY = r'^[a-zA-Z0-9\.:;\-_/\\ ]*$'
-RE_VALID_SERIES_KEY = re.compile(VALID_SERIES_KEY)
-
 
 class Client(object):
 
@@ -62,8 +59,6 @@ class Client(object):
         return series
 
     def create_series(self, key=None):
-        if key and not RE_VALID_SERIES_KEY.match(key):
-            raise ValueError("Series key must match the following regex: %s" % (VALID_SERIES_KEY,))
 
         params = {}
         if key is not None:

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -124,9 +124,6 @@ class Client(object):
         return self._write(series_type, series_val, data)
 
     def write_key(self, series_key, data):
-        if series_key and not RE_VALID_SERIES_KEY.match(series_key):
-            raise ValueError("Series key must match the following regex: %s" % (VALID_SERIES_KEY,))
-
         series_type = 'key'
         series_val = series_key
         return self._write(series_type, series_val, data)
@@ -145,9 +142,6 @@ class Client(object):
         return self._increment(series_type, series_val, data)
 
     def increment_key(self, series_key, data):
-        if series_key and not RE_VALID_SERIES_KEY.match(series_key):
-            raise ValueError("Series key must match the following regex: %s" % (VALID_SERIES_KEY,))
-
         series_type = 'key'
         series_val = series_key
         return self._increment(series_type, series_val, data)

--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -100,9 +100,6 @@ class ClientTest(TestCase):
         expected = Series('id', 'my-key.tag1.1', '', {}, ['my-key', 'tag1'])
         self.assertEqual(series, expected)
 
-    def test_create_series_validity_error(self):
-        with self.assertRaises(ValueError):
-            series = self.client.create_series('key.b%^.test')
 
     def test_update_series(self):
         update = Series('id', 'key', 'name', {'key1': 'value1'}, ['tag1'])


### PR DESCRIPTION
We allow all UTF-8 characters. Other clients have no regex validation either.
