### PR TITLE
use datetime.strptime instead of parser

### DIFF
--- a/tempodb/base.py
+++ b/tempodb/base.py
@@ -5,9 +5,7 @@ tempodb/client.py
 
 Copyright (c) 2012 TempoDB, Inc. All rights reserved.
 """
-
-import simplejson
-from dateutil import parser
+from datetime import datetime
 
 
 class Database(object):
@@ -33,7 +31,7 @@ class Series(object):
         return str(self.__dict__)
 
     def __eq__(self, other):
-       return self.__dict__ == other.__dict__
+        return self.__dict__ == other.__dict__
 
     @staticmethod
     def from_json(json):
@@ -56,7 +54,7 @@ class DataPoint(object):
         return "t: %s, v: %s" % (self.ts, self.value)
 
     def __eq__(self, other):
-       return self.__dict__ == other.__dict__
+        return self.__dict__ == other.__dict__
 
     def to_json(self):
         json = {
@@ -67,7 +65,7 @@ class DataPoint(object):
 
     @staticmethod
     def from_json(json):
-        ts = parser.parse(json.get('t', ''))
+        ts = datetime.strptime(json.get('t', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
         value = json.get('v', None)
         dp = DataPoint(ts, value)
         return dp
@@ -86,14 +84,14 @@ class DataSet(object):
         return str(self.__dict__)
 
     def __eq__(self, other):
-       return self.__dict__ == other.__dict__
+        return self.__dict__ == other.__dict__
 
     @staticmethod
     def from_json(json):
         series = Series.from_json(json.get('series', {}))
 
-        start_date = parser.parse(json.get('start', ''))
-        end_date = parser.parse(json.get('end', ''))
+        start_date = datetime.strptime(json.get('start', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
+        end_date = datetime.strptime(json.get('end', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
 
         data = [DataPoint.from_json(dp) for dp in json.get("data", [])]
         summary = Summary.from_json(json.get('summary', {})) if 'summary' in json else None

--- a/tests/base/datapoint_tests.py
+++ b/tests/base/datapoint_tests.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 import datetime
-from unittest2 import TestCase
+from unittest import TestCase
 
 from tempodb import DataPoint
 
@@ -19,7 +19,7 @@ class DataPointTest(TestCase):
         ts = datetime.datetime(2012, 3, 27, 1, 2, 3, 4)
         dp = DataPoint(ts, 12.34)
         expected = {
-            't': '2012-03-27T01:02:03.000004Z',
+            't': '2012-03-27T01:02:03.000004',
             'v': 12.34
         }
         json = dp.to_json()

--- a/tests/base/datapoint_tests.py
+++ b/tests/base/datapoint_tests.py
@@ -19,7 +19,7 @@ class DataPointTest(TestCase):
         ts = datetime.datetime(2012, 3, 27, 1, 2, 3, 4)
         dp = DataPoint(ts, 12.34)
         expected = {
-            't': '2012-03-27T01:02:03.000004',
+            't': '2012-03-27T01:02:03.000004Z',
             'v': 12.34
         }
         json = dp.to_json()
@@ -27,7 +27,7 @@ class DataPointTest(TestCase):
 
     def test_from_json(self):
         json = {
-            't': '2012-03-27T01:02:03.000004',
+            't': '2012-03-27T01:02:03.000004Z',
             'v': 12.34
         }
         dp = DataPoint.from_json(json)

--- a/tests/base/dataset_tests.py
+++ b/tests/base/dataset_tests.py
@@ -31,8 +31,8 @@ class DataSetTest(TestCase):
                 'tags': ['tag1', 'tag2'],
                 'attributes': {'key1': 'value1'},
             },
-            'start': '2012-03-27T00:00:00.000',
-            'end': '2012-03-28T00:00:00.000',
+            'start': '2012-03-27T00:00:00.000Z',
+            'end': '2012-03-28T00:00:00.000Z',
             'data': [],
             'summary': {'min': 45.5}
         }

--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -133,9 +133,9 @@ class ClientTest(TestCase):
                 "tags": [],
                 "attributes": {}
             },
-            "start": "2012-03-27T00:00:00.000",
-            "end": "2012-03-28T00:00:00.000",
-            "data": [{"t": "2012-03-27T00:00:00.000", "v": 12.34}],
+            "start": "2012-03-27T00:00:00.000Z",
+            "end": "2012-03-28T00:00:00.000Z",
+            "data": [{"t": "2012-03-27T00:00:00.000Z", "v": 12.34}],
             "summary": {}
         }""")
 
@@ -160,9 +160,9 @@ class ClientTest(TestCase):
                 "tags": [],
                 "attributes": {}
             },
-            "start": "2012-03-27T00:00:00.000",
-            "end": "2012-03-28T00:00:00.000",
-            "data": [{"t": "2012-03-27T00:00:00.000", "v": 12.34}],
+            "start": "2012-03-27T00:00:00.000Z",
+            "end": "2012-03-28T00:00:00.000Z",
+            "data": [{"t": "2012-03-27T00:00:00.000Z", "v": 12.34}],
             "summary": {}
         }""")
 
@@ -187,9 +187,9 @@ class ClientTest(TestCase):
                 "tags": [],
                 "attributes": {}
             },
-            "start": "2012-03-27T00:00:00.000",
-            "end": "2012-03-28T00:00:00.000",
-            "data": [{"t": "2012-03-27T00:00:00.000", "v": 12.34}],
+            "start": "2012-03-27T00:00:00.000Z",
+            "end": "2012-03-28T00:00:00.000Z",
+            "data": [{"t": "2012-03-27T00:00:00.000Z", "v": 12.34}],
             "summary": {}
         }""")
 
@@ -214,9 +214,9 @@ class ClientTest(TestCase):
                 "tags": [],
                 "attributes": {}
             },
-            "start": "2012-03-27T00:00:00.000",
-            "end": "2012-03-28T00:00:00.000",
-            "data": [{"t": "2012-03-27T00:00:00.000", "v": 12.34}],
+            "start": "2012-03-27T00:00:00.000Z",
+            "end": "2012-03-28T00:00:00.000Z",
+            "data": [{"t": "2012-03-27T00:00:00.000Z", "v": 12.34}],
             "summary": {}
         }]""")
 
@@ -401,7 +401,7 @@ class ClientTest(TestCase):
         self.client.session.post.assert_called_once_with(
             'https://example.com/v1/multi/',
             auth=('key', 'secret'),
-            data= simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
+            data=simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
             headers=self.post_headers
         )
         self.assertEqual(result, '')
@@ -425,7 +425,7 @@ class ClientTest(TestCase):
         self.client.session.post.assert_called_once_with(
             'https://example.com/v1/multi/',
             auth=('key', 'secret'),
-            data= simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
+            data=simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
             headers=self.post_headers
         )
 
@@ -444,7 +444,7 @@ class ClientTest(TestCase):
         self.client.session.post.assert_called_once_with(
             'https://example.com/v1/multi/',
             auth=('key', 'secret'),
-            data= simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
+            data=simplejson.dumps(data, default=tempodb.DATETIME_HANDLER),
             headers=self.post_headers
         )
         self.assertEqual(result, '')


### PR DESCRIPTION
its much faster and we're always parsing ISO 8601 format
