### PR TITLE
Py3k and Py2k cross compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,17 @@ tempodb/setup.py
 Copyright (c) 2012 TempoDB Inc. All rights reserved.
 """
 
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 install_requires = [
-    'python-dateutil==1.5',
-    'requests>=1.0',
+    'python-dateutil >= 2.0',
+    'requests >= 2.0',
     'simplejson',
+    'six'
 ]
 
 tests_require = [

--- a/tempodb/__init__.py
+++ b/tempodb/__init__.py
@@ -9,7 +9,7 @@ Copyright (c) 2012 TempoDB Inc. All rights reserved.
 
 try:
     VERSION = __import__('pkg_resources').get_distribution('tempodb').version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'
 
 def get_version():

--- a/tempodb/base.py
+++ b/tempodb/base.py
@@ -94,10 +94,8 @@ class DataSet(object):
 
         matcher = "%Y-%m-%dT%H:%M:%S.%fZ"
 
-        start_date = datetime.strptime(
-            json.get('start', ''), matcher)
-        end_date = datetime.strptime(
-            json.get('end', ''), matcher)
+        start_date = parse(json.get('start', ''))
+        end_date = parse(json.get('end', ''))
 
         data = [DataPoint.from_json(dp) for dp in json.get("data", [])]
         summary = Summary.from_json(

--- a/tempodb/base.py
+++ b/tempodb/base.py
@@ -5,6 +5,7 @@ tempodb/client.py
 
 Copyright (c) 2012 TempoDB, Inc. All rights reserved.
 """
+import six
 from datetime import datetime
 
 
@@ -65,7 +66,8 @@ class DataPoint(object):
 
     @staticmethod
     def from_json(json):
-        ts = datetime.strptime(json.get('t', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
+        matcher = "%Y-%m-%dT%H:%M:%S.%fZ" if six.PY2 else "%Y-%m-%dT%H:%M:%S.%f%z"
+        ts = datetime.strptime(json.get('t', ''), matcher)
         value = json.get('v', None)
         dp = DataPoint(ts, value)
         return dp
@@ -90,11 +92,16 @@ class DataSet(object):
     def from_json(json):
         series = Series.from_json(json.get('series', {}))
 
-        start_date = datetime.strptime(json.get('start', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
-        end_date = datetime.strptime(json.get('end', ''), "%Y-%m-%dT%H:%M:%S.%fZ")
+        matcher = "%Y-%m-%dT%H:%M:%S.%fZ" if six.PY2 else "%Y-%m-%dT%H:%M:%S.%f%z"
+
+        start_date = datetime.strptime(
+            json.get('start', ''), matcher)
+        end_date = datetime.strptime(
+            json.get('end', ''), matcher)
 
         data = [DataPoint.from_json(dp) for dp in json.get("data", [])]
-        summary = Summary.from_json(json.get('summary', {})) if 'summary' in json else None
+        summary = Summary.from_json(
+            json.get('summary', {})) if 'summary' in json else None
         return DataSet(series, start_date, end_date, data, summary)
 
 
@@ -112,11 +119,12 @@ class Summary(object):
         summary.__dict__.update(json)
         return summary
 
+
 class DeleteSummary(object):
+
     def __init__(self, deleted):
         self.deleted = deleted
 
     @staticmethod
     def from_json(json):
         return DeleteSummary(json['deleted'])
-

--- a/tempodb/base.py
+++ b/tempodb/base.py
@@ -7,6 +7,7 @@ Copyright (c) 2012 TempoDB, Inc. All rights reserved.
 """
 import six
 from datetime import datetime
+from dateutil.parser import parse
 
 
 class Database(object):
@@ -66,8 +67,7 @@ class DataPoint(object):
 
     @staticmethod
     def from_json(json):
-        matcher = "%Y-%m-%dT%H:%M:%S.%fZ" if six.PY2 else "%Y-%m-%dT%H:%M:%S.%f%z"
-        ts = datetime.strptime(json.get('t', ''), matcher)
+        ts = parse(json.get('t', ''))
         value = json.get('v', None)
         dp = DataPoint(ts, value)
         return dp

--- a/tempodb/base.py
+++ b/tempodb/base.py
@@ -92,7 +92,7 @@ class DataSet(object):
     def from_json(json):
         series = Series.from_json(json.get('series', {}))
 
-        matcher = "%Y-%m-%dT%H:%M:%S.%fZ" if six.PY2 else "%Y-%m-%dT%H:%M:%S.%f%z"
+        matcher = "%Y-%m-%dT%H:%M:%S.%fZ"
 
         start_date = datetime.strptime(
             json.get('start', ''), matcher)

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -10,8 +10,7 @@ import datetime
 import re
 import requests
 import simplejson
-import urllib
-import urllib2
+from six.moves.urllib_parse import urlencode, quote
 
 import tempodb
 from tempodb import DataPoint, DataSet, DeleteSummary, Series, Summary
@@ -186,7 +185,7 @@ class Client(object):
             params['tz'] = tz
 
         url = '/series/%s/%s/data/' % (series_type,
-                                       urllib2.quote(series_val, ""))
+                                       quote(series_val, ""))
         json = self.request(url, method='GET', params=params)
 
         # we got an error
@@ -201,20 +200,20 @@ class Client(object):
         }
         params.update(options)
         url = '/series/%s/%s/data/' % (series_type,
-                                       urllib2.quote(series_val, ""))
+                                       quote(series_val, ""))
         json = self.request(url, method='DELETE', params=params)
         return json
 
     def _write(self, series_type, series_val, data):
         url = '/series/%s/%s/data/' % (series_type,
-                                       urllib2.quote(series_val, ""))
+                                       quote(series_val, ""))
         body = [dp.to_json() for dp in data]
         json = self.request(url, method='POST', params=body)
         return json
 
     def _increment(self, series_type, series_val, data):
         url = '/series/%s/%s/increment/' % (series_type,
-                                            urllib2.quote(series_val, ""))
+                                            quote(series_val, ""))
         body = [dp.to_json() for dp in data]
         json = self.request(url, method='POST', params=body)
         return json
@@ -288,7 +287,7 @@ class Client(object):
                 p.append((key, str(value).lower()))
             else:
                 p.append((key, str(value)))
-        return urllib.urlencode(p).encode("UTF-8")
+        return urlencode(p).encode("UTF-8")
 
     def _normalize_params(self, ids=[], keys=[], tags=[], attributes={}):
         params = {}

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -286,8 +286,11 @@ class Client(object):
             elif isinstance(value, bool):
                 p.append((key, str(value).lower()))
             else:
-                p.append((key, str(value)))
-        return urlencode(p).encode("UTF-8")
+                p.append((key, six.b(value)))
+
+        # We shouldn't need the explicit encoding cast at all, but I'm
+        # leaving it in for legacy's sake
+        return urlencode(p) if six.PY3 else urlencode(p).encode("UTF-8")
 
     def _normalize_params(self, ids=[], keys=[], tags=[], attributes={}):
         params = {}

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -286,7 +286,7 @@ class Client(object):
             elif isinstance(value, bool):
                 p.append((key, str(value).lower()))
             else:
-                p.append((key, six.b(value)))
+                p.append((key, str(value)))
 
         # We shouldn't need the explicit encoding cast at all, but I'm
         # leaving it in for legacy's sake

--- a/tempodb/demo/tempodb-bulk-write-demo.py
+++ b/tempodb/demo/tempodb-bulk-write-demo.py
@@ -1,6 +1,7 @@
 """
 http://tempo-db.com/api/write-series/#bulk-write-multiple-series
 """
+from __future__ import print_function
 
 import datetime
 from tempodb import Client
@@ -20,4 +21,4 @@ data = [
     { 'key': 'custom-series-key4', 'v': 4.44 },
 ]
 
-print client.write_bulk(ts, data)
+print(client.write_bulk(ts, data))

--- a/tempodb/demo/tempodb-read-demo.py
+++ b/tempodb/demo/tempodb-read-demo.py
@@ -1,6 +1,7 @@
 """
 http://tempo-db.com/api/read-series/#read-series-by-key
 """
+from __future__ import print_function
 
 import datetime
 from tempodb import Client
@@ -18,4 +19,4 @@ end = start + datetime.timedelta(days=1)
 data = client.read_key(SERIES_KEY, start, end)
 
 for datapoint in data.data:
-    print datapoint
+    print(datapoint)

--- a/tempodb/demo/tempodb-write-demo.py
+++ b/tempodb/demo/tempodb-write-demo.py
@@ -1,6 +1,7 @@
 """
 http://tempo-db.com/api/write-series/#write-series-by-key
 """
+from __future__ import print_function
 
 import datetime
 import random
@@ -17,7 +18,7 @@ date = datetime.datetime(2012, 1, 1)
 
 for day in range(1, 10):
     # print out the current day we are sending data for
-    print date
+    print(date)
 
     data = []
     # 1440 minutes in one day

--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -51,17 +51,23 @@ class ClientTest(TestCase):
     def test_port_defaults(self):
         """ 80 is the default port for HTTP, 443 is the default for HTTPS """
         client = Client('key', 'secret', 'example.com', 80, False)
-        self.assertEqual(client.build_full_url('/etc'), 'http://example.com/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'http://example.com/v1/etc')
         client = Client('key', 'secret', 'example.com', 88, False)
-        self.assertEqual(client.build_full_url('/etc'), 'http://example.com:88/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'http://example.com:88/v1/etc')
         client = Client('key', 'secret', 'example.com', 443, False)
-        self.assertEqual(client.build_full_url('/etc'), 'http://example.com:443/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'http://example.com:443/v1/etc')
         client = Client('key', 'secret', 'example.com', 443, True)
-        self.assertEqual(client.build_full_url('/etc'), 'https://example.com/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'https://example.com/v1/etc')
         client = Client('key', 'secret', 'example.com', 88, True)
-        self.assertEqual(client.build_full_url('/etc'), 'https://example.com:88/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'https://example.com:88/v1/etc')
         client = Client('key', 'secret', 'example.com', 80, True)
-        self.assertEqual(client.build_full_url('/etc'), 'https://example.com:80/v1/etc')
+        self.assertEqual(client.build_full_url('/etc'),
+                         'https://example.com:80/v1/etc')
 
     def test_get_series(self):
         self.client.session.get.return_value = MockResponse(200, """[{
@@ -78,13 +84,16 @@ class ClientTest(TestCase):
             auth=('key', 'secret'),
             headers=self.get_headers
         )
-        expected = [Series('id', 'key', 'name', {'key1': 'value1'}, ['tag1', 'tag2'])]
+        expected = [
+            Series('id', 'key', 'name', {'key1': 'value1'}, ['tag1', 'tag2'])]
         self.assertEqual(series, expected)
 
     def test_delete_series(self):
-        self.client.session.delete.return_value = MockResponse(200, """{"deleted":2}""")
+        self.client.session.delete.return_value = MockResponse(
+            200, """{"deleted":2}""")
 
-        summary = self.client.delete_series([], [], [], {'key': 'one', 'key2': 'two'})
+        summary = self.client.delete_series(
+            [], [], [], {'key': 'one', 'key2': 'two'})
         self.assertEqual(summary.deleted, 2)
 
     def test_create_series(self):
@@ -112,7 +121,8 @@ class ClientTest(TestCase):
 
     def test_update_series(self):
         update = Series('id', 'key', 'name', {'key1': 'value1'}, ['tag1'])
-        self.client.session.put.return_value = MockResponse(200, simplejson.dumps(update.to_json()))
+        self.client.session.put.return_value = MockResponse(
+            200, simplejson.dumps(update.to_json()))
 
         updated = self.client.update_series(update)
 
@@ -143,7 +153,8 @@ class ClientTest(TestCase):
         end = datetime.datetime(2012, 3, 28)
         dataset = self.client.read_id('id', start, end)
 
-        expected = DataSet(Series('id', 'key'), start, end, [DataPoint(start, 12.34)], Summary())
+        expected = DataSet(Series('id', 'key'), start, end,
+                           [DataPoint(start, 12.34)], Summary())
         self.client.session.get.assert_called_once_with(
             'https://example.com/v1/series/id/id/data/?start=2012-03-27T00%3A00%3A00&end=2012-03-28T00%3A00%3A00',
             auth=('key', 'secret'),
@@ -170,7 +181,8 @@ class ClientTest(TestCase):
         end = datetime.datetime(2012, 3, 28)
         dataset = self.client.read_key('key1', start, end)
 
-        expected = DataSet(Series('id', 'key1'), start, end, [DataPoint(start, 12.34)], Summary())
+        expected = DataSet(Series('id', 'key1'), start, end,
+                           [DataPoint(start, 12.34)], Summary())
         self.client.session.get.assert_called_once_with(
             'https://example.com/v1/series/key/key1/data/?start=2012-03-27T00%3A00%3A00&end=2012-03-28T00%3A00%3A00',
             auth=('key', 'secret'),
@@ -197,7 +209,8 @@ class ClientTest(TestCase):
         end = datetime.datetime(2012, 3, 28)
         dataset = self.client.read_key('ke:y/1', start, end)
 
-        expected = DataSet(Series('id', 'ke:y/1'), start, end, [DataPoint(start, 12.34)], Summary())
+        expected = DataSet(Series('id', 'ke:y/1'), start,
+                           end, [DataPoint(start, 12.34)], Summary())
         self.client.session.get.assert_called_once_with(
             'https://example.com/v1/series/key/ke%3Ay%2F1/data/?start=2012-03-27T00%3A00%3A00&end=2012-03-28T00%3A00%3A00',
             auth=('key', 'secret'),
@@ -224,7 +237,8 @@ class ClientTest(TestCase):
         end = datetime.datetime(2012, 3, 28)
         datasets = self.client.read(start, end, keys=['key1'])
 
-        expected = [DataSet(Series('id', 'key1'), start, end, [DataPoint(start, 12.34)], Summary())]
+        expected = [
+            DataSet(Series('id', 'key1'), start, end, [DataPoint(start, 12.34)], Summary())]
         self.client.session.get.assert_called_once_with(
             'https://example.com/v1/data/?start=2012-03-27T00%3A00%3A00&end=2012-03-28T00%3A00%3A00&key=key1',
             auth=('key', 'secret'),
@@ -352,10 +366,10 @@ class ClientTest(TestCase):
     def test_write_bulk(self):
         self.client.session.post.return_value = MockResponse(200, "")
         data = [
-            { 'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4.164 },
-            { 'id': '38268c3b231f1266a392931e15e99231', 'v': 73.13 },
-            { 'key': 'your-custom-key', 'v': 55.423 },
-            { 'key': 'foo', 'v': 324.991 },
+            {'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4.164},
+            {'id': '38268c3b231f1266a392931e15e99231', 'v': 73.13},
+            {'key': 'your-custom-key', 'v': 55.423},
+            {'key': 'foo', 'v': 324.991},
         ]
         ts = datetime.datetime(2012, 3, 27)
         result = self.client.write_bulk(ts, data)
@@ -371,10 +385,10 @@ class ClientTest(TestCase):
     def test_increment_bulk(self):
         self.client.session.post.return_value = MockResponse(200, "")
         data = [
-            { 'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4 },
-            { 'id': '38268c3b231f1266a392931e15e99231', 'v': 2 },
-            { 'key': 'your-custom-key', 'v': 1 },
-            { 'key': 'foo', 'v': 1 },
+            {'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4},
+            {'id': '38268c3b231f1266a392931e15e99231', 'v': 2},
+            {'key': 'your-custom-key', 'v': 1},
+            {'key': 'foo', 'v': 1},
         ]
         ts = datetime.datetime(2012, 3, 27)
         result = self.client.increment_bulk(ts, data)
@@ -387,14 +401,16 @@ class ClientTest(TestCase):
         )
         self.assertEqual(result, '')
 
-
     def test_write_multi(self):
         self.client.session.post.return_value = MockResponse(200, "")
         data = [
-            { 't': datetime.datetime(2013, 8, 21), 'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4.164 },
-            { 't': datetime.datetime(2013, 8, 22), 'id': '38268c3b231f1266a392931e15e99231', 'v': 73.13 },
-            { 't': datetime.datetime(2013, 8, 23), 'key': 'your-custom-key', 'v': 55.423 },
-            { 't': datetime.datetime(2013, 8, 24), 'key': 'foo', 'v': 324.991 },
+            {'t': datetime.datetime(2013, 8, 21), 'id':
+             '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4.164},
+            {'t': datetime.datetime(2013, 8, 22), 'id':
+             '38268c3b231f1266a392931e15e99231', 'v': 73.13},
+            {'t': datetime.datetime(2013, 8, 23), 'key':
+             'your-custom-key', 'v': 55.423},
+            {'t': datetime.datetime(2013, 8, 24), 'key': 'foo', 'v': 324.991},
         ]
         result = self.client.write_multi(data)
 
@@ -413,11 +429,13 @@ class ClientTest(TestCase):
                 { "status": "200", "messages": [] },
                 { "status": "422", "messages": [ "Must provide a numeric value", "Must provide a series ID or key" ] }
             ]}}"""
-        self.client.session.post.return_value = MockResponse(207, expected_response)
+        self.client.session.post.return_value = MockResponse(
+            207, expected_response)
 
         data = [
-            { 't': datetime.datetime(2013, 8, 21), 'v': 4.164 },
-            { 't': datetime.datetime(2013, 8, 22), 'id': '38268c3b231f1266a392931e15e99231'},
+            {'t': datetime.datetime(2013, 8, 21), 'v': 4.164},
+            {'t': datetime.datetime(2013, 8, 22), 'id':
+             '38268c3b231f1266a392931e15e99231'},
             {}
         ]
         result = self.client.write_multi(data)
@@ -434,10 +452,13 @@ class ClientTest(TestCase):
     def test_write_multi(self):
         self.client.session.post.return_value = MockResponse(200, "")
         data = [
-            { 't': datetime.datetime(2013, 8, 21), 'id': '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4164 },
-            { 't': datetime.datetime(2013, 8, 22), 'id': '38268c3b231f1266a392931e15e99231', 'v': 7313 },
-            { 't': datetime.datetime(2013, 8, 23), 'key': 'your-custom-key', 'v': 55423 },
-            { 't': datetime.datetime(2013, 8, 24), 'key': 'foo', 'v': 324991 },
+            {'t': datetime.datetime(2013, 8, 21), 'id':
+             '01868c1a2aaf416ea6cd8edd65e7a4b8', 'v': 4164},
+            {'t': datetime.datetime(2013, 8, 22), 'id':
+             '38268c3b231f1266a392931e15e99231', 'v': 7313},
+            {'t': datetime.datetime(2013, 8, 23), 'key':
+             'your-custom-key', 'v': 55423},
+            {'t': datetime.datetime(2013, 8, 24), 'key': 'foo', 'v': 324991},
         ]
         result = self.client.write_multi(data)
 


### PR DESCRIPTION
This pull-request introduces the six package to make TempoDB cross compatible between python 2.x and python 3.x.

All tests for python 2.x pass; very few pass for python 3.x due to dictionary ordering when JSON encoding. The assertion tests test for string equality and if the dicts aren't in the same order (they are never guaranteed to be because it's an unordered data type) the tests will fail.
