### PR TITLE
Fix escaping spaces in series keys after server fix

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TempoDB Python API'
-copyright = u'2013, TempoDB Inc.'
+copyright = u'2014, TempoDB Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/tempodb/client.py
+++ b/tempodb/client.py
@@ -16,7 +16,7 @@ def make_series_url(key):
     :rtype: string"""
 
     url = urlparse.urljoin(endpoint.SERIES_ENDPOINT, 'key/')
-    url = urlparse.urljoin(url, urllib.quote_plus(key))
+    url = urlparse.urljoin(url, urllib.quote(key))
     return url
 
 


### PR DESCRIPTION
Now that the server correctly handles spaces in URLs, the client needs to be updated accordingly.
